### PR TITLE
Fix G(a,u) for isStandardBuchholz

### DIFF
--- a/pss-vs-buchholz/common.js
+++ b/pss-vs-buchholz/common.js
@@ -711,7 +711,7 @@ function timesBuchholz(a,n){
  * @returns {BuchholzTerm[]}
  */
 function G(a,u){
-  if (a instanceof Array) return a.flatMap(G);
+  if (a instanceof Array) return a.flatMap(function(e){return G(e,u);});
   else if (a instanceof Object) return u<=a.sub?[a.inner].concat(G(a.inner,u)):[];
   else return [];
 }


### PR DESCRIPTION
## 修正内容

```diff
function G(a,u){
-  if (a instanceof Array) return a.flatMap(G);
+  if (a instanceof Array) return a.flatMap(function(e){return G(e,u);});
  else if (a instanceof Object) return u<=a.sub?[a.inner].concat(G(a.inner,u)):[];
  else return [];
}
```

## 問題
`Array.prototype.flatMap` は、コールバックを `f(element, index, array)` として呼び出します。
したがって、ポイントフリースタイルで `G` を渡すと、`u` には引き回されてきたレベルではなく、
**配列のインデックス**が束縛されます。和の場合、最初の項は `u = 0` で、`k` 番目の項は
`u = k` で処理されます。

`G` は `isStandardBuchholz` からしか使われていないため、このバグにより、標準形でない項の
一部が標準形だと判定されます。

## 最小反例

**誤って受理される項** — `D_0(D_1(0)+D_0(D_2(0)))`、すなわち
$`\psi_0(\Omega_1 + \psi_0(\Omega_2))`$。2番目の項がレベル 0 ではなく 1 で処理されるため、
`1 <= 0` が偽となり、$`\Omega_2`$ が集合に入りません。本来の条件では
$`\Omega_2 \lt \Omega_1 + \psi_0(\Omega_2)`$ が必要ですが、これは成り立ちません。

**誤って拒否される項** — `D_1(D_0(D_1(0))+D_0(0))`、すなわち
$`\psi_1(\psi_0(\Omega_1) + \psi_0(0))`$。最初の項がレベル 1 ではなく 0 で処理されるため、
`0 <= 0` が真となり、本来は空であるべき集合に2つの要素が入ります。

## 再現方法

```js
isStandardBuchholz(p("D_0(D_1(0)+D_0(D_2(0)))"))
// 現行版: true、期待値: false
```

```js
isStandardBuchholz(p("D_1(D_0(D_1(0))+D_0(0))"))
// 現行版: false、期待値: true
```

修正後は、どちらも期待値と一致します。
