### PR TITLE
security fix: remove polyfill.io

### DIFF
--- a/loaderBitStreamTranslater/index.html
+++ b/loaderBitStreamTranslater/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>loader.c Bit Stream to Proof Translater</title>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script src="https://peterolson.github.io/BigInteger.js/BigInteger.min.js"></script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <script src="./script.js"></script>

--- a/pss-vs-buchholz/common.js
+++ b/pss-vs-buchholz/common.js
@@ -711,7 +711,7 @@ function timesBuchholz(a,n){
  * @returns {BuchholzTerm[]}
  */
 function G(a,u){
-  if (a instanceof Array) return a.flatMap(G);
+  if (a instanceof Array) return a.flatMap(function(e){return G(e,u);});
   else if (a instanceof Object) return u<=a.sub?[a.inner].concat(G(a.inner,u)):[];
   else return [];
 }


### PR DESCRIPTION
https://naruyoko.github.io/googology/loaderBitStreamTranslater を開くと不審なログインダイアログが表示されます。

当初 mathjax 3 を IE11 でも動かすために 
```html
<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
```
を付けるサンプルがありましたが、現在ドメイン polyfill.io は管理者が変わり、その後にサプライチェーン攻撃を行ったことがあると報告されています。

cf. https://sansec.io/research/polyfill-supply-chain-attack
cf. https://googology.fandom.com/ja/wiki/MediaWiki%E3%83%BB%E3%83%88%E3%83%BC%E3%82%AF:Common.js#polyfill.io%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6

削除しておくのが安全と思われます。
フォークしたら検出されて、気になったので。

## テスト
修正後、不審なログインダイアログが表示されなくなることを確認しました。